### PR TITLE
Fix concurrent gauge access

### DIFF
--- a/pkg/gofr/metrics/register.go
+++ b/pkg/gofr/metrics/register.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"context"
+	"sync"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
@@ -42,6 +43,7 @@ type metricsManager struct {
 // and otel/metric supports only asynchronous gauge (Float64ObservableGauge).
 // And if we use the otel/metric, we would not be able to have support for labels, Hence created a custom type to implement it.
 type float64Gauge struct {
+	mu           sync.RWMutex
 	observations map[attribute.Set]float64
 }
 
@@ -145,6 +147,9 @@ func (m *metricsManager) NewGauge(name, desc string) {
 // callbackFunc implements the callback function for the underlying asynchronous gauge
 // it observes the current state of all previous set() calls.
 func (f *float64Gauge) callbackFunc(_ context.Context, o metric.Float64Observer) error {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
 	for attrs, val := range f.observations {
 		o.Observe(val, metric.WithAttributeSet(attrs))
 	}
@@ -242,7 +247,9 @@ func (m *metricsManager) SetGauge(name string, value float64, labels ...string) 
 }
 
 func (f *float64Gauge) set(val float64, attrs attribute.Set) {
+	f.mu.Lock()
 	f.observations[attrs] = val
+	f.mu.Unlock()
 }
 
 // getAttributes validates the given labels and convert them to corresponding otel attributes.

--- a/pkg/gofr/metrics/register_test.go
+++ b/pkg/gofr/metrics/register_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -158,4 +159,22 @@ func Test_NewMetricsManagerLabelHighCardinality(t *testing.T) {
 	log := testutil.StdoutOutputForFunc(logs)
 
 	assert.Contains(t, log, `metrics counter-test has high cardinality: 24`, "TEST Failed. high cardinality of metrics")
+}
+
+func Test_SetGauge_Concurrent(t *testing.T) {
+	manager := NewMetricsManager(exporters.Prometheus("test-app", "v1.0.0"),
+		logging.NewMockLogger(logging.INFO))
+
+	manager.NewGauge("conc-gauge", "concurrent gauge test")
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(v int) {
+			defer wg.Done()
+			manager.SetGauge("conc-gauge", float64(v))
+		}(i)
+	}
+
+	wg.Wait()
 }


### PR DESCRIPTION
## Summary
- add RW mutex for float64Gauge
- protect observations map with the mutex
- add a test exercising concurrent SetGauge

## Testing
- `GOTOOLCHAIN=local go test ./...` *(fails: go.work requires go >= 1.24.0)*

------
https://chatgpt.com/codex/tasks/task_e_6843ca4f2b108329b7d91b0ded2b2df4